### PR TITLE
Support textContent that has spaces

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -131,7 +131,7 @@ role="button">
       z: 1,
 
       attached: function() {
-        if (this.textContent && !this.textContent.match(/\s+/)) {
+        if (this.textContent && this.textContent.match(/\S+/)) {
           console.warn('Using textContent to label the button is deprecated. Use the "label" property instead');
           this.label = this.textContent;
         }


### PR DESCRIPTION
Currently, the check fails for a <paper-button> that contains text that has a space.
Change the test to check what it is supposed to - whether there's any non-whitespace
content.
