### PR TITLE
Moving the paper-ripple import to the button-base component.

### DIFF
--- a/paper-button-base.html
+++ b/paper-button-base.html
@@ -19,6 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link href="../polymer/polymer.html" rel="import">
 <link href="../core-focusable/core-focusable.html" rel="import">
+<link href="../paper-ripple/paper-ripple.html" rel="import">
 
 <polymer-element name="paper-button-base" tabindex="0">
 

--- a/paper-button.html
+++ b/paper-button.html
@@ -57,7 +57,6 @@ The opacity of the ripple is not customizable via CSS.
 -->
 
 <link href="../polymer/polymer.html" rel="import">
-<link href="../paper-ripple/paper-ripple.html" rel="import">
 <link href="../paper-shadow/paper-shadow.html" rel="import">
 
 <link href="paper-button-base.html" rel="import">


### PR DESCRIPTION
The paper-ripple element was used by the button-base, not directly by the button component.
