### PR TITLE
A toggle button can now be active even before it is pressed.

### DIFF
--- a/paper-button-base.html
+++ b/paper-button-base.html
@@ -36,19 +36,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       activeChanged: function() {
         this.super();
 
-        if (this.$.ripple) {
-          if (this.active) {
-            // FIXME: remove when paper-ripple can have a default 'down' state.
-            if (!this.lastEvent) {
-              var rect = this.getBoundingClientRect();
-              this.lastEvent = {
-                x: rect.left + rect.width / 2,
-                y: rect.top + rect.height / 2
-              }
+        this.super();
+
+        if (this.active) {
+          // FIXME: remove when paper-ripple can have a default 'down' state.
+          if (!this.lastEvent) {
+            var rect = this.getBoundingClientRect();
+            this.lastEvent = {
+              x: rect.left + rect.width / 2,
+              y: rect.top + rect.height / 2
             }
-            this.$.ripple.downAction(this.lastEvent);
-          } else {
-            this.$.ripple.upAction();
+          }
+          this.ensureRippleExist();
+          this.$.ripple.downAction(this.lastEvent);
+        } else {
+          if (this.$.ripple) {
+              this.$.ripple.upAction();
           }
         }
 
@@ -86,28 +89,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       },
 
       downAction: function(e) {
+        this.ensureRippleExist();
         this._downAction();
+        this.lastEvent = e;
+      },
 
-        if (this.hasAttribute('noink')) {
+      ensureRippleExist: function() {
+        if (this.hasAttribute('noink') || this.$.ripple) {
           return;
         }
 
-        this.lastEvent = e;
-        if (!this.$.ripple) {
-          var ripple = document.createElement('paper-ripple');
-          ripple.setAttribute('id', 'ripple');
-          ripple.setAttribute('fit', '');
-          if (this.recenteringTouch) {
-            ripple.classList.add('recenteringTouch');
-          }
-          if (!this.fill) {
-            ripple.classList.add('circle');
-          }
-          this.$.ripple = ripple;
-          this.shadowRoot.insertBefore(ripple, this.shadowRoot.firstChild);
-          // No need to forward the event to the ripple because the ripple
-          // is triggered in activeChanged
+        var ripple = document.createElement('paper-ripple');
+        ripple.setAttribute('id', 'ripple');
+        ripple.setAttribute('fit', '');
+        if (this.recenteringTouch) {
+          ripple.classList.add('recenteringTouch');
         }
+        if (!this.fill) {
+          ripple.classList.add('circle');
+        }
+        this.$.ripple = ripple;
+        this.shadowRoot.insertBefore(ripple, this.shadowRoot.firstChild);
       }
 
     };


### PR DESCRIPTION
Since the button ripple is created only after the first DownAction, toggle buttons that were defined as "active" in the HTML or was set as "active" through javascript had no visual effect. Now the ripple can be created during the activeChanged event if not previously created.
HTML test markup:
<paper-icon-button icon="delete" active toggle></paper-icon-button>
