### PR TITLE
Add margin on core-icons inside paper-button

### DIFF
--- a/paper-button.html
+++ b/paper-button.html
@@ -124,6 +124,14 @@ role="button">
         flex-basis: 0.000000001px;
       }
 
+      ::content > core-icon:first-child {
+        margin-right: 0.45em;
+      }
+
+      ::content > core-icon:last-child {
+        margin-left: 0.45em;
+      }
+
     </style>
 
     <template if="{{raised}}">


### PR DESCRIPTION
Added margin-right for the first icon inside a paper-button and margin-left for the last icon.
